### PR TITLE
HTC-769: Connected backend to profile page message button

### DIFF
--- a/client/src/accountSummary/member/messaging/SendMessage.js
+++ b/client/src/accountSummary/member/messaging/SendMessage.js
@@ -6,29 +6,72 @@
  *
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from "prop-types";
+import {sendMessage} from "../../../services/MessageService"
 import LargeTextArea from "../../../common/forms/LargeTextArea";
 import SubmitButton from "../../../common/forms/SubmitButton";
+import {useEffect} from "react";
+import {checkIfErrorsExistInMapping, validateInput} from "../../../registration/registrationUtils";
 
 function SendMessage(props) {
     //username currently unused, but intended as component which will handle post request to add message to database
-    const {username, otherUser} = props;
-    function onSubmit(){
-        return;
+    const {receiverName, receiverId} = props;
+    const [content, setContent] = useState(undefined);
+    const [contentError, setContentError] = useState(undefined);
+    useEffect(() => {
+        content !== undefined && validateInput(content, setContentError);
+    }, [content]);
+
+    const isFormValid = () => {
+
+        const errors = {
+            content: false,
+        }
+
+        errors.fullDes = validateInput(content, setContentError);
+
+        return !(checkIfErrorsExistInMapping(errors));
     }
+
+    //function for input checks on submit
+    function onSubmitMessage() {
+        if (isFormValid()) {
+            const message = {
+                receiverId: receiverId,
+                content: content
+            }
+            sendMessage(message)
+                .then(res => res.json())
+                .then(data => {
+                    if (data.sent) {
+                        alert("Message sent successfully");
+                    } else {
+                        alert("Message not sent successfully")
+                    }
+                })
+                .catch(err => {
+                    alert('error sending message: ' + err.message);
+                });
+        }
+    }
+
     return(
         <div>
-            <p>To {otherUser}: </p>
-            <LargeTextArea label={"What would you like to contact this member about? "} />
-            <SubmitButton className={"btn btn-green mb-6 w-1/2 text-base py-2"} onClick={onSubmit}/>
+            <p>To {receiverName}: </p>
+            <LargeTextArea className={`${contentError && "border-red-500"} input`}
+                           label={"What would you like to contact this member about? "}
+                           onChange={(e) => setContent(e.target.value)}/>
+            <SubmitButton   className={"btn btn-green mb-6 w-1/2 text-base py-2"}
+                            onClick={onSubmitMessage}
+                            onSubmit={onSubmitMessage}/>
         </div>
     )
 }
 
 SendMessage.propTypes = {
-    username: PropTypes.string.isRequired,
-    otherUser: PropTypes.string.isRequired
+    receiverName: PropTypes.string.isRequired,
+    receiverId: PropTypes.number.isRequired
 };
 
 export default SendMessage;

--- a/client/src/accountSummary/member/messaging/__test__/ConversationCard.test.js
+++ b/client/src/accountSummary/member/messaging/__test__/ConversationCard.test.js
@@ -22,7 +22,7 @@ describe('ConversationCard', () => {
 
             //when
             const renderer = new ShallowRenderer();
-            renderer.render(<ConversationCard {...props}/>);
+            renderer.render(<ConversationCard onClick={jest.fn()} {...props}/>);
             const result = renderer.getRenderOutput();
             //then
             expect(result).toMatchSnapshot();

--- a/client/src/accountSummary/member/messaging/__test__/SendMessage.test.js
+++ b/client/src/accountSummary/member/messaging/__test__/SendMessage.test.js
@@ -19,8 +19,8 @@ describe('SendMessage', () => {
         it('should match snapshot test of SendMessage', () => {
             //given
             const props = {
-                username: "messageMember1",
-                otherUser: "otherUser1",
+                receiverName: "otherUser1",
+                receiverId: 2,
             }
             //when
             const component = renderer.create(<SendMessage {...props}/>);

--- a/client/src/accountSummary/member/messaging/__test__/__snapshots__/ConversationCard.test.js.snap
+++ b/client/src/accountSummary/member/messaging/__test__/__snapshots__/ConversationCard.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ConversationCard Snapshot test should match snapshot test 1`] = `
 <section
   className="card-container mt-0"
+  onClick={[MockFunction]}
 >
   <div
     className="inline ml-6 align-middle "

--- a/client/src/accountSummary/member/messaging/__test__/__snapshots__/SendMessage.test.js.snap
+++ b/client/src/accountSummary/member/messaging/__test__/__snapshots__/SendMessage.test.js.snap
@@ -15,8 +15,9 @@ exports[`SendMessage Snapshot test should match snapshot test of SendMessage 1`]
     </label>
     
     <textarea
-      className="undefined undefined input"
+      className="undefined undefined undefined input"
       cols="50"
+      onChange={[Function]}
     />
   </div>
   <label>

--- a/client/src/memberSearch/profilePage/ProfilePage.js
+++ b/client/src/memberSearch/profilePage/ProfilePage.js
@@ -15,6 +15,8 @@ import SendMessage from "../../accountSummary/member/messaging/SendMessage";
 
 function ProfilePage(props) {
     const {
+        uid,
+
         username,
         age,
 
@@ -206,7 +208,7 @@ function ProfilePage(props) {
                     </div>
 
                 </div>
-                {sendingMessage && <SendMessage otherUser={username} username={"messageMember1"}/>}
+                {sendingMessage && <SendMessage receiverName={username} receiverId={uid}/>}
             </div>
         </div>
     );
@@ -215,6 +217,7 @@ function ProfilePage(props) {
 
 ProfilePage.propTypes =
     {
+        uid: PropTypes.number.isRequired,
         username: PropTypes.string.isRequired,
         age: PropTypes.number.isRequired,
 

--- a/client/src/memberSearch/profilePage/ProfilePageContainer.js
+++ b/client/src/memberSearch/profilePage/ProfilePageContainer.js
@@ -117,6 +117,7 @@ const ProfilePageContainer = props => {
                     {error
                         ? <div>{ERROR}</div>
                         : <ProfilePage
+                            uid={profile.uid}
                             username={profile.username}
                             age={getMemberAge(profile.birthYear)}
                             gender={profile.gender}

--- a/client/src/memberSearch/profilePage/__tests__/ProfilePage.test.js
+++ b/client/src/memberSearch/profilePage/__tests__/ProfilePage.test.js
@@ -15,6 +15,7 @@ describe('ProfilePage', () => {
         it("should render correctly regardless of properties", () => {
             // given
             const props = {
+                uid: 2,
                 username: "Babar",
                 age: 40,
 

--- a/server/controllers/messagesController.js
+++ b/server/controllers/messagesController.js
@@ -10,9 +10,9 @@ const db = require('../models');
 const {Op} = require("sequelize");
 const Message = db.message;
 
-const createMessage = (req,uid) => {
+const createMessage = (req) => {
     const messageEntry = {
-        senderId: uid,
+        senderId: req.user.uid,
         receiverId: req.body.receiverId,
         content: req.body.content
     }


### PR DESCRIPTION
# [769](https://github.com/rachellegelden/Home-Together-Canada/issues/769)

## Summary
Connected Profile page message button to send a message to database
included/added client side validation
fixed some tests that were passing with errors and not noticed last week.
 

## Relevant Motivation & Context
Required as the profile page is first point of contact between members for initiating a conversation.

## Testing Instructions
have 2 members created
Sign in as one member. Search for other members profile page. On page, click message button to show sendMessage component. Type message. Click submit - message sent alert should appear. 
Leave message box blank - click submit again - validation css should appear
Login in postman - search all messages - should return your original message - check that uid's are correct and content is as well

npm test in root
console - look for errors
inspect code

## Developer checklist prior to opening this pull request:

- [ ] PR merges to the applicable branch (develop or feature branch)
- [ ] Commits adhere to GitHub compliance (Issue #)
- [ ] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [ ] Unit tests pass
- [ ] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
