### PR TITLE
HTC-367: fixed header bug

### DIFF
--- a/client/src/accountSummary/AccountSummaryContainer.js
+++ b/client/src/accountSummary/AccountSummaryContainer.js
@@ -6,7 +6,7 @@
  *
  */
 
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
 import {connect} from "react-redux";
 import PropTypes from "prop-types";
@@ -26,6 +26,11 @@ import {mockMessages} from "../mockData/MockMessageData"
 const AccountSummaryContainer = props => {
     const { active } = props;
     const {accountType, selected} = useLocation().state;
+    const [selectedSubpage, setSelectedSubpage] = useState(selected);
+
+    useEffect(() => {
+        setSelectedSubpage(selected);
+    }, [selected])
 
     const MEMBER_SIDEBAR = [
         ...MEMBER_SUBPAGES,
@@ -54,7 +59,6 @@ const AccountSummaryContainer = props => {
 
     const options = accountType === USER_TYPES.MEMBER ? MEMBER_SIDEBAR : BUSINESS_SIDEBAR;
 
-    const [selectedSubpage, setSelectedSubpage] = useState(selected);
 
     const subpageComponent = (subpage) => {
         switch (subpage) {


### PR DESCRIPTION
# [HTC-637](https://github.com/rachellegelden/Home-Together-Canada/issues/367)

## Summary
When the user is in the account summary section, and they use the dropdown in the header to navigate to another section of the account summary it works as expected. 

## Relevant Motivation & Context
Bug fix

## Testing Instructions
1. Login
2. Go to Account summary
3. Navigate to a different subpage using the dropdown

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
