### PR TITLE
HTC-793: display business logos on listing cards

### DIFF
--- a/client/src/admin/manageListings/PendingListingCards.js
+++ b/client/src/admin/manageListings/PendingListingCards.js
@@ -14,6 +14,7 @@ import {AiFillCheckCircle} from "react-icons/ai";
 import {AiFillCloseCircle} from "react-icons/ai";
 import Modal from 'react-modal';
 import Paginate from "../../common/forms/Paginate";
+import {getLogoURL} from "../../common/utils/imageUtils";
 
 
 const ADMIN_TEXT = {
@@ -74,7 +75,7 @@ function PendingListingCards(props) {
             <div className={"flex"} key={listing.id}>
                 <section className={"w-full"}>
                     <BusinessListingCard
-                        logo={listing.id.toString()}
+                        logo={listing.logo && getLogoURL(listing.logo)}
                         title={listing.title}
                         businessName={listing.businessName}
                         shortDescription={listing.shortDescription}

--- a/client/src/admin/manageListings/__tests__/__snapshots__/PendingListingCards.test.js.snap
+++ b/client/src/admin/manageListings/__tests__/__snapshots__/PendingListingCards.test.js.snap
@@ -31,7 +31,7 @@ exports[`PendingListingCards Container test should match snapshot test regardles
           >
             <img
               className="float-left w-24 h-24 mx-4 "
-              src="20"
+              src="HTC_Logo.jpg"
             />
             <div
               className="inline align-middle "
@@ -214,7 +214,7 @@ exports[`PendingListingCards Container test should match snapshot test regardles
           >
             <img
               className="float-left w-24 h-24 mx-4 "
-              src="30"
+              src="HTC_Logo.jpg"
             />
             <div
               className="inline align-middle "

--- a/client/src/admin/manageListings/__tests__/__snapshots__/PendingListingCards.test.js.snap
+++ b/client/src/admin/manageListings/__tests__/__snapshots__/PendingListingCards.test.js.snap
@@ -30,9 +30,8 @@ exports[`PendingListingCards Container test should match snapshot test regardles
             className="card-container mt-0"
           >
             <img
-              alt=""
-              className="float-left w-24 h-auto mx-4 "
-              src="HTC_Logo.jpg"
+              className="float-left w-24 h-24 mx-4 "
+              src="20"
             />
             <div
               className="inline align-middle "
@@ -214,9 +213,8 @@ exports[`PendingListingCards Container test should match snapshot test regardles
             className="card-container mt-0"
           >
             <img
-              alt=""
-              className="float-left w-24 h-auto mx-4 "
-              src="HTC_Logo.jpg"
+              className="float-left w-24 h-24 mx-4 "
+              src="30"
             />
             <div
               className="inline align-middle "

--- a/client/src/searchServicesClassifieds/listingCards/BusinessListingCard.js
+++ b/client/src/searchServicesClassifieds/listingCards/BusinessListingCard.js
@@ -10,7 +10,6 @@
 import React from 'react';
 import PropTypes from "prop-types";
 import Moment from 'react-moment';
-import HTC_Logo from "../../images/HTC_Logo.jpg";
 
 
 function BusinessListingCard(props) {
@@ -18,8 +17,7 @@ function BusinessListingCard(props) {
 
     return (
         <section className={"card-container mt-0"}>
-            {/*TODO: replace HTC_Logo with logo Prop*/}
-            <img className={"float-left w-24 h-auto mx-4 "} src={HTC_Logo} alt={""}/>
+            <img className={"float-left w-24 h-24 mx-4 "} src={logo}/>
             <div className={"inline align-middle "}>
                 <label className={"font-semibold justify-between"}> {title} </label>
                 {/*{shortDescription}*/}

--- a/client/src/searchServicesClassifieds/listingCards/BusinessListingCard.js
+++ b/client/src/searchServicesClassifieds/listingCards/BusinessListingCard.js
@@ -10,14 +10,14 @@
 import React from 'react';
 import PropTypes from "prop-types";
 import Moment from 'react-moment';
-
+import HTC_Logo from "../../images/HTC_Logo.jpg";
 
 function BusinessListingCard(props) {
     const {logo, title, businessName, shortDescription, datePosted} = props;
 
     return (
         <section className={"card-container mt-0"}>
-            <img className={"float-left w-24 h-24 mx-4 "} src={logo}/>
+            <img className={"float-left w-24 h-24 mx-4 "} src={logo ? logo : HTC_Logo}/>
             <div className={"inline align-middle "}>
                 <label className={"font-semibold justify-between"}> {title} </label>
                 {/*{shortDescription}*/}

--- a/client/src/searchServicesClassifieds/listingCards/__tests__/__snapshots__/BusinessListingCard.test.js.snap
+++ b/client/src/searchServicesClassifieds/listingCards/__tests__/__snapshots__/BusinessListingCard.test.js.snap
@@ -5,9 +5,8 @@ exports[`BusinessListingCard Container test should match snapshot test 1`] = `
   className="card-container mt-0"
 >
   <img
-    alt=""
-    className="float-left w-24 h-auto mx-4 "
-    src="HTC_Logo.jpg"
+    className="float-left w-24 h-24 mx-4 "
+    src="Potato"
   />
   <div
     className="inline align-middle "

--- a/client/src/searchServicesClassifieds/listingResults/ListingResults.js
+++ b/client/src/searchServicesClassifieds/listingResults/ListingResults.js
@@ -15,7 +15,7 @@ import {listingContext} from "../SearchListingContainer";
 import BusinessListingCard from "../listingCards/BusinessListingCard";
 import MemberListingCard from "../listingCards/MemberListingCard";
 import {USER_TYPES as USER_TYPE} from "../../common/constants/users";
-import HTC_Logo from "../../images/HTC_Logo.jpg"
+import {getLogoURL} from "../../common/utils/imageUtils";
 
 const NUM_RESULTS = 7;
 
@@ -62,7 +62,7 @@ function ListingResults(props) {
                         key={listing.id}
                     >
                         <BusinessListingCard
-                            logo={HTC_Logo}
+                            logo={listing.business.logo && getLogoURL(listing.business.logo)}
                             title={listing.title}
                             businessName={listing.business.businessName}
                             shortDescription={listing.shortDescription}

--- a/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResults.test.js.snap
+++ b/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResults.test.js.snap
@@ -11,9 +11,8 @@ exports[`ListingResultsContainer Snapshot test should match snapshot test if lis
         className="card-container mt-0"
       >
         <img
-          alt=""
-          className="float-left w-24 h-auto mx-4 "
-          src="HTC_Logo.jpg"
+          className="float-left w-24 h-24 mx-4 "
+          src={null}
         />
         <div
           className="inline align-middle "

--- a/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResults.test.js.snap
+++ b/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResults.test.js.snap
@@ -12,7 +12,7 @@ exports[`ListingResultsContainer Snapshot test should match snapshot test if lis
       >
         <img
           className="float-left w-24 h-24 mx-4 "
-          src={null}
+          src="HTC_Logo.jpg"
         />
         <div
           className="inline align-middle "

--- a/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResultsContainer.test.js.snap
+++ b/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResultsContainer.test.js.snap
@@ -14,9 +14,8 @@ exports[`ListingResultsContainer Snapshot test should match snapshot test if lis
           className="card-container mt-0"
         >
           <img
-            alt=""
-            className="float-left w-24 h-auto mx-4 "
-            src="HTC_Logo.jpg"
+            className="float-left w-24 h-24 mx-4 "
+            src={null}
           />
           <div
             className="inline align-middle "

--- a/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResultsContainer.test.js.snap
+++ b/client/src/searchServicesClassifieds/listingResults/__tests__/__snapshots__/ListingResultsContainer.test.js.snap
@@ -15,7 +15,7 @@ exports[`ListingResultsContainer Snapshot test should match snapshot test if lis
         >
           <img
             className="float-left w-24 h-24 mx-4 "
-            src={null}
+            src="HTC_Logo.jpg"
           />
           <div
             className="inline align-middle "

--- a/server/controllers/listingController.js
+++ b/server/controllers/listingController.js
@@ -132,7 +132,7 @@ const searchBusinessListings = async (searchArea, categoryName, subcategoryNames
         where: {
             isDeleted: false,
             dateAdminApproved: {
-                [Op.gt]: new Date()
+                [Op.lt]: new Date()
             },
             dateExpired: {
                 [Op.or]: {


### PR DESCRIPTION
# [HTC-793](https://github.com/rachellegelden/Home-Together-Canada/issues/793)

## Summary
Business logos will now be displayed on the cards

## Relevant Motivation & Context
The HTC logo won't be displayed anymore

## Testing Instructions
Look at some listings for businesses that do and don't have logos

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [ ] Unit tests pass
- [ ] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
