### PR TITLE
HTC-811/Fixed Previous message content shows in container

### DIFF
--- a/client/src/accountSummary/member/messaging/SendMessage.js
+++ b/client/src/accountSummary/member/messaging/SendMessage.js
@@ -19,6 +19,7 @@ function SendMessage(props) {
     const {receiverUsername, receiverId} = props;
     const [content, setContent] = useState(undefined);
     const [contentError, setContentError] = useState(undefined);
+    const [messageIsSent,setMessageIsSent] =useState(false);
 
     useEffect(() => {
         content !== undefined && validateInput(content, setContentError);
@@ -35,6 +36,7 @@ function SendMessage(props) {
     //function for input checks on submit
     function onSubmitMessage(e) {
         e.preventDefault();
+        setMessageIsSent(false);
         if (isFormValid()) {
             const message = {
                 receiverUsername: receiverUsername,
@@ -49,6 +51,8 @@ function SendMessage(props) {
                     } else {
                         alert("Sorry, the person you are trying to reach has deleted their account.")
                     }
+                    setContent("");
+                    setMessageIsSent(true);
                 })
                 .catch(err => {
                     alert('error sending message: ' + err.message);
@@ -59,8 +63,9 @@ function SendMessage(props) {
     return(
         <div>
             <br/><p>To {receiverUsername}: </p>
-            <LargeTextArea className={`${contentError && "border-red-500"} input`}
+            <LargeTextArea className={ `${contentError && !messageIsSent && "border-red-500"} input`}
                            label={"What would you like to contact this member about? "}
+                           value={content}
                            onChange={(e) => setContent(e.target.value)}
             />
             <SubmitButton   className={"btn btn-green mb-6 w-1/2 text-base py-2"}


### PR DESCRIPTION
# [#811](https://github.com/rachellegelden/Home-Together-Canada/issues/811)

## Summary
Fixed Previous message content shows in container

## Relevant Motivation & Context
Bug is needed to be fixed.

## Testing Instructions
- login as a member
- Go to messaging and send 3 messages to see how its display.

## Developer checklist prior to opening this pull request:
- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [x] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [x] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [x] Checkout and launch this branch locally
- [x] Review code structure
- [x] Review test coverage
- [x] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE