### PR TITLE
HTC-815: added max lengths for fields in DB

### DIFF
--- a/server/models/abstractUser.js
+++ b/server/models/abstractUser.js
@@ -17,7 +17,7 @@ module.exports = (DataTypes, sequelize) => {
             unique: true
         },
         username: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(50),
             allowNull: false,
             unique: true,
         },
@@ -35,15 +35,15 @@ module.exports = (DataTypes, sequelize) => {
             unique: true
         },
         firstName: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         lastName: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         phoneNumber: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(16),
             allowNull: false
         },
         isBanned: {
@@ -55,22 +55,22 @@ module.exports = (DataTypes, sequelize) => {
             type: DataTypes.STRING,
         },
         addressLine1: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         addressLine2: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         city: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(60),
             allowNull: false
         },
         province: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(4),
             allowNull: false
         },
         postalCode: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(6),
             allowNull: false
         },
         hasDifferentMailingAddress: {
@@ -79,22 +79,22 @@ module.exports = (DataTypes, sequelize) => {
             defaultValue: false
         },
         mailingAddressLine1: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         mailingAddressLine2: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         mailingCity: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(60),
             allowNull: false
         },
         mailingProvince: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(4),
             allowNull: false
         },
         mailingPostalCode: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(6),
             allowNull: false
         }
     });

--- a/server/models/areaOfInterest.js
+++ b/server/models/areaOfInterest.js
@@ -6,8 +6,6 @@
  *
  */
 
-const booleanOverlap = require('@turf/boolean-overlap').default;
-
 module.exports = (DataTypes, sequelize) => {
     return sequelize.define('AreaOfInterest', {
         uid: {
@@ -15,11 +13,11 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false
         },
         province: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(4),
             allowNull: false
         },
         city: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(60),
             allowNull: false
         },
         radius: {

--- a/server/models/businessAccount.js
+++ b/server/models/businessAccount.js
@@ -15,7 +15,7 @@ module.exports = (DataTypes, sequelize) => {
             unique: true
         },
         businessName: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         logo: {
@@ -30,11 +30,11 @@ module.exports = (DataTypes, sequelize) => {
             type: DataTypes.STRING
         },
         businessPhoneNumber: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(16),
             allowNull: false
         },
         businessCellPhoneNumber: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(16),
             allowNull: false
         },
         isNationWide: {
@@ -43,19 +43,19 @@ module.exports = (DataTypes, sequelize) => {
             defaultValue: false
         },
         mapAddressLine1: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         mapAddressLine2: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         mapCity: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(60)
         },
         mapProvince: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(4)
         },
         mapPostalCode: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(6)
         },
         mapLatitude: {
             type: DataTypes.DECIMAL(10,7)   // 10 total digits, 7 digit decimal accuracy

--- a/server/models/listing.js
+++ b/server/models/listing.js
@@ -14,7 +14,7 @@ module.exports = (DataTypes, sequelize) => {
         },
         // stringified JSON object with all listing fields
         fields: {
-            type: DataTypes.TEXT, // set a character limit on this
+            type: DataTypes.TEXT, // TODO: set a character limit on this after adding server-side validation
             allowNull: false
         },
         isDeleted: {

--- a/server/models/listingCategory.js
+++ b/server/models/listingCategory.js
@@ -15,7 +15,7 @@ module.exports = (DataTypes, sequelize) => {
             autoIncrement: false
         },
         name: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         isClassified: {

--- a/server/models/listingSubcategory.js
+++ b/server/models/listingSubcategory.js
@@ -9,7 +9,7 @@
 module.exports = (DataTypes, sequelize) => {
     return sequelize.define('ListingSubcategory', {
         name: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         }
     });

--- a/server/models/livesWith.js
+++ b/server/models/livesWith.js
@@ -10,7 +10,7 @@
 module.exports = (DataTypes, sequelize) => {
     return sequelize.define("LivesWith", {
         relationship: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(50),
             allowNull: false
         }
     })

--- a/server/models/memberAccount.js
+++ b/server/models/memberAccount.js
@@ -25,21 +25,21 @@ module.exports = (DataTypes, sequelize) => {
           defaultValue: true
         },
         deactivationReason: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         gender: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(50),
             allowNull: false
         },
         genderDescription: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
         },
         birthYear: {
             type: DataTypes.INTEGER,
             allowNull: false
         },
         status: {
-          type: DataTypes.STRING,
+          type: DataTypes.STRING(100),
           allowNull: false
         },
         minMonthlyBudget: {
@@ -55,67 +55,67 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false
         },
         homeToShareDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         isInterestedInBuyingHome: {
           type: DataTypes.BOOLEAN,
           allowNull: false
         },
         interestInBuyingHomeDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         isReligionImportant: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         religionDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         isDietImportant: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         dietDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         hasHealthMobilityIssues: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         healthMobilityIssuesDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         hasAllergies: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         allergiesDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         hasPets: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         petsDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         isSmoker: {
             type: DataTypes.BOOLEAN,
             allowNull: false
         },
         smokingDescription: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(100)
         },
         numRoommates: {                  // -1 means any number
             type: DataTypes.INTEGER,
             allowNull: false
         },
         workStatus: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(100),
             allowNull: false
         },
         bio: {
-            type: DataTypes.STRING
+            type: DataTypes.STRING(2000)
         },
 
         // PREFERENCES
@@ -128,11 +128,11 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false
         },
         statusPreference: {
-            type: DataTypes.STRING, // stringified array
+            type: DataTypes.STRING(1000), // stringified array
             allowNull: false
         },
         numRoommatesPreference: {
-            type: DataTypes.STRING, // stringified array, -1 means any number
+            type: DataTypes.STRING(50), // stringified array, -1 means any number
             allowNull: false
         },
         minBudgetPreference: {
@@ -156,7 +156,7 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false
         },
         genderPreference: {
-            type: DataTypes.STRING,     // stringified array
+            type: DataTypes.STRING(400),     // stringified array
             allowNull: false
         },
         religionPreference: {

--- a/server/models/message.js
+++ b/server/models/message.js
@@ -13,7 +13,7 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false,
         },
         senderUsername: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(50),
             allowNull: false,
         },
         receiverId: {
@@ -21,11 +21,11 @@ module.exports = (DataTypes, sequelize) => {
             allowNull: false,
         },
         receiverUsername: {
-            type: DataTypes.STRING,
+            type: DataTypes.STRING(50),
             allowNull: false,
         },
         content: {
-            type: DataTypes.STRING(1000),
+            type: DataTypes.STRING(2000),
             allowNull: false,
         }
     });


### PR DESCRIPTION
# [HTC-815](https://github.com/rachellegelden/Home-Together-Canada/issues/815)

## Summary
Added max lengths to string fields in the DB. Roughly followed this [guide](https://www.geekslop.com/features/technology-articles/2016/here-are-the-recommended-maximum-data-length-limits-for-common-database-and-programming-fields)

## Relevant Motivation & Context
So that users don't give us absurdly long strings as input

## Testing Instructions
1. look at each model and make sure that the max length is reasonable for that field. Note `.STRING` fields without a number specified default to 255 characters

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [x] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
