### PR TITLE
HTC-821: make table routes private to dev instances

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -33,6 +33,8 @@ if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
     app.use(cors(corsOptions));
 }
 
+console.log('NODE_ENV: ', process.env.NODE_ENV);
+
 app.use(expressValidator());
 
 // Sets up the Express app to handle data parsing

--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ const messageRoutes = require('./routes/messageRoutes');
 const db = require("./models");
 const listingCategories = require('./controllers/listingCategoryController');
 const listingSubcategories = require('./controllers/listingSubcategoryController');
+const { DEVELOPMENT } = require('./constants/environmentConstants');
 
 const app = express();
 
@@ -25,7 +26,7 @@ app.use(express.static(path.join(__dirname, '../client/build')));
 // Serve static files that are in the public folder
 app.use(express.static(__dirname + '/public'));
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     const corsOptions = {
         origin: 'http://localhost:3002',
         credentials: true
@@ -84,7 +85,8 @@ app.use(function(req, res, next) {
 
 // error handler
 app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
+  console.log('88: ', app.get('env'));
+    // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 

--- a/server/constants/environmentConstants.js
+++ b/server/constants/environmentConstants.js
@@ -1,0 +1,5 @@
+const DEVELOPMENT = 'development';
+
+module.exports = {
+    DEVELOPMENT
+}

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -7,7 +7,8 @@
  */
 
 const { DataTypes, Sequelize } = require('sequelize');
-const env = process.env.NODE_ENV || 'development';
+const { DEVELOPMENT } = require('../constants/environmentConstants');
+const env = process.env.NODE_ENV || DEVELOPMENT;
 const dbConfig = require(__dirname + '/../db.config.js')[env];
 
 const sequelize = new Sequelize({

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -66,21 +66,6 @@ router.post('/create/',
     }
 );
 
-// list of usernames for all admins
-router.get('/all/',
-    isLoggedIn,
-    userIsAdmin,
-    function (req, res, next) {
-        memberAccounts.getAllAdminUsernames()
-            .then(admins => {
-                const formattedListAdmins = admins.map(admin => getUsernameFromAbstractUser(admin.AbstractUser));
-                res.status(200).json({ admins: formattedListAdmins });
-            })
-            .catch(err => {
-                res.status(500).json({ err: err.message });
-            });
-    }
-);
 
 router.post('/ban/user/',
     isLoggedIn,
@@ -292,5 +277,23 @@ router.get('/export/businesses/',
             });
     }
 );
+
+if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+    // list of usernames for all admins
+    router.get('/all/',
+        isLoggedIn,
+        userIsAdmin,
+        function (req, res, next) {
+            memberAccounts.getAllAdminUsernames()
+                .then(admins => {
+                    const formattedListAdmins = admins.map(admin => getUsernameFromAbstractUser(admin.AbstractUser));
+                    res.status(200).json({ admins: formattedListAdmins });
+                })
+                .catch(err => {
+                    res.status(500).json({ err: err.message });
+                });
+        }
+    );
+}
 
 module.exports = router;

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -22,6 +22,7 @@ const usersValidator = require('../controllers/validators/userControllerValidato
 const { getUsernameFromAbstractUser } = require('../controllers/utils/accountControllerUtils');
 const listingValidator = require('../controllers/validators/listingControllerValidator');
 const { LISTING_VALIDATION_METHODS } = require('../controllers/validators/listingControllerValidatorUtils');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
 // NOTE: this route is only for development purposes as a means to make the first admin
 router.get('/dev/create/',
@@ -278,7 +279,7 @@ router.get('/export/businesses/',
     }
 );
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     // list of usernames for all admins
     router.get('/all/',
         isLoggedIn,

--- a/server/routes/businessRoutes.js
+++ b/server/routes/businessRoutes.js
@@ -34,10 +34,12 @@ const uploads = multer({
     }
 }).single('image');
 
-// Get all business users
-router.get('/all/', function(req, res, next) {
-    businessAccounts.findAllBusinessAccounts(req, res);
-});
+if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+    // Get all business users
+    router.get('/all/', function(req, res, next) {
+        businessAccounts.findAllBusinessAccounts(req, res);
+    });
+}
 
 // Create a business user
 router.post('/create/', usersValidator.validate('createBusinessUser'),

--- a/server/routes/businessRoutes.js
+++ b/server/routes/businessRoutes.js
@@ -16,6 +16,7 @@ const businessAccounts = require('../controllers/businessAccountController');
 const abstractUsers = require('../controllers/abstractUserController');
 const usersValidator = require('../controllers/validators/userControllerValidator');
 const { isLoggedIn, userIsBusiness } = require('./routeUtils');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
 const storage = multer.diskStorage({
     destination: function (req, file, cb) {
@@ -34,7 +35,7 @@ const uploads = multer({
     }
 }).single('image');
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     // Get all business users
     router.get('/all/', function(req, res, next) {
         businessAccounts.findAllBusinessAccounts(req, res);

--- a/server/routes/listingRoutes.js
+++ b/server/routes/listingRoutes.js
@@ -22,6 +22,7 @@ const listingAssignedSubcategoryController = require('../controllers/listingAssi
 const memberListingLocationController = require('../controllers/memberListingLocationController');
 const multer = require("multer");
 const { MEMBER_SERVICE_CATEGORIES } = require('../constants/listingConstants');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
 const storage = multer.diskStorage({
     destination: function (req, file, cb) {
@@ -209,7 +210,7 @@ router.post('/search/', listingValidator.validate(LISTING_VALIDATION_METHODS.SEA
     }
 );
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     router.get('/categories/', function(req, res, next) {
         listingCategoryController.findAllListingCategories(req, res);
     });

--- a/server/routes/listingRoutes.js
+++ b/server/routes/listingRoutes.js
@@ -11,7 +11,6 @@ const router = express.Router();
 const { validationResult } = require('express-validator/check');
 const includes = require('lodash/includes');
 const last = require('lodash/last');
-const fs = require('fs');
 
 const listingValidator = require('../controllers/validators/listingControllerValidator');
 const { LISTING_VALIDATION_METHODS, CATEGORY_FORM_VALIDATION_DICT } = require('../controllers/validators/listingControllerValidatorUtils');
@@ -210,24 +209,26 @@ router.post('/search/', listingValidator.validate(LISTING_VALIDATION_METHODS.SEA
     }
 );
 
-router.get('/categories/', function(req, res, next) {
-    listingCategoryController.findAllListingCategories(req, res);
-});
+if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+    router.get('/categories/', function(req, res, next) {
+        listingCategoryController.findAllListingCategories(req, res);
+    });
 
-router.get('/subcategories/', function(req, res, next) {
-    listingSubcategoryController.findAllListingSubcategories(req, res);
-});
+    router.get('/subcategories/', function(req, res, next) {
+        listingSubcategoryController.findAllListingSubcategories(req, res);
+    });
 
-router.get('/listings/', function(req, res, next) {
-    listingController.findAllListings(req, res);
-});
+    router.get('/listings/', function(req, res, next) {
+        listingController.findAllListings(req, res);
+    });
 
-router.get('/listingAssignedSubcategories/', function (req, res){
-    listingAssignedSubcategoryController.findAllEntries(req, res);
-});
+    router.get('/listingAssignedSubcategories/', function (req, res){
+        listingAssignedSubcategoryController.findAllEntries(req, res);
+    });
 
-router.get('/memberListingLocations/', function (req, res){
-    memberListingLocationController.findAllMemberListingLocationEntries(req, res);
-});
+    router.get('/memberListingLocations/', function (req, res){
+        memberListingLocationController.findAllMemberListingLocationEntries(req, res);
+    });
+}
 
 module.exports = router;

--- a/server/routes/memberRoutes.js
+++ b/server/routes/memberRoutes.js
@@ -22,11 +22,12 @@ const { getCircularFeatureFromLocation } = require('../controllers/utils/locatio
 const { getListOfAreaOfInterestObjects } = require('../controllers/utils/areaOfInterestUtils');
 const { isLoggedIn, userIsMember, userIsInactive, userIsActive } = require('./routeUtils');
 
-
-// Get all member accounts
-router.get('/all/', function (req, res, next) {
-    memberAccounts.findAllMemberAccounts(req, res);
-});
+if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+    // Get all member accounts
+    router.get('/all/', function (req, res, next) {
+        memberAccounts.findAllMemberAccounts(req, res);
+    });
+}
 
 // add validation to isInterestedInBuyingHome fields
 router.post('/create/', usersValidator.validate('createMemberUser'),

--- a/server/routes/memberRoutes.js
+++ b/server/routes/memberRoutes.js
@@ -21,8 +21,9 @@ const { getRoommatesUsernames } = require('../controllers/utils/statusUtils');
 const { getCircularFeatureFromLocation } = require('../controllers/utils/locationUtils');
 const { getListOfAreaOfInterestObjects } = require('../controllers/utils/areaOfInterestUtils');
 const { isLoggedIn, userIsMember, userIsInactive, userIsActive } = require('./routeUtils');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     // Get all member accounts
     router.get('/all/', function (req, res, next) {
         memberAccounts.findAllMemberAccounts(req, res);

--- a/server/routes/messageRoutes.js
+++ b/server/routes/messageRoutes.js
@@ -13,8 +13,9 @@ const { isLoggedIn, userIsMember } = require('./routeUtils');
 const abstractUsers = require('../controllers/abstractUserController');
 const message = require('../controllers/messagesController');
 const messageValidator = require('../controllers/validators/messageControllerValidator');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
-if (process.env.NODE_ENV === 'developmental' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     router.get('/all/',
         isLoggedIn,
         userIsMember,

--- a/server/routes/messageRoutes.js
+++ b/server/routes/messageRoutes.js
@@ -14,6 +14,16 @@ const abstractUsers = require('../controllers/abstractUserController');
 const message = require('../controllers/messagesController');
 const messageValidator = require('../controllers/validators/messageControllerValidator');
 
+if (process.env.NODE_ENV === 'developmental' || !process.env.NODE_ENV) {
+    router.get('/all/',
+        isLoggedIn,
+        userIsMember,
+        function (req, res){
+            message.findAllMessagesForAllUsers(req,res);
+        }
+    );
+}
+
 router.post('/create/',
     isLoggedIn,
     userIsMember,
@@ -42,14 +52,6 @@ router.get('/uid/',
             .catch(err => {
                 res.status(500).send({ message: err.message || "User ID does not exit."})
             });
-    }
-);
-
-router.get('/all/',
-    isLoggedIn,
-    userIsMember,
-    function (req, res){
-        message.findAllMessagesForAllUsers(req,res);
     }
 );
 

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -16,11 +16,12 @@ const abstractUsers = require('../controllers/abstractUserController');
 const businessAccounts = require('../controllers/businessAccountController');
 const memberAccounts = require('../controllers/memberAccountController');
 const { isLoggedIn } = require('./routeUtils');
+const { DEVELOPMENT } = require('../constants/environmentConstants');
 
 // TODO: Take out after confirming output on production
 console.log('NODE_ENV: ', process.env.NODE_ENV);
 
-if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+if (process.env.NODE_ENV === DEVELOPMENT || !process.env.NODE_ENV) {
     // get all abstract users
     router.get('/all/', function (req, res, next) {
         abstractUsers.findAllAbstractUsers(req, res);

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -17,15 +17,15 @@ const businessAccounts = require('../controllers/businessAccountController');
 const memberAccounts = require('../controllers/memberAccountController');
 const { isLoggedIn } = require('./routeUtils');
 
-// Create abstract user
-router.post('/create/', function (req, res, next) {
-    abstractUsers.createAbstractUser(req, res);
-});
+// TODO: Take out after confirming output on production
+console.log('NODE_ENV: ', process.env.NODE_ENV);
 
-// get all abstract users
-router.get('/all/', function (req, res, next) {
-    abstractUsers.findAllAbstractUsers(req, res);
-});
+if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+    // get all abstract users
+    router.get('/all/', function (req, res, next) {
+        abstractUsers.findAllAbstractUsers(req, res);
+    });
+}
 
 // check if user is authenticated
 router.get('/checkAuth/',isLoggedIn, function(req, res, next) {
@@ -115,12 +115,6 @@ router.get('/delete/',
             .catch(err => {
                 res.status(500).json({ err: err.message });
             });
-});
-
-// Get a specific abstract user
-// This route MUST BE LAST
-router.get('/:id', function (req, res, next) {
-    abstractUsers.findAbstractUser(req, res);
 });
 
 module.exports = router;


### PR DESCRIPTION
# [HTC-821](https://github.com/rachellegelden/Home-Together-Canada/issues/821)

## Summary
All table routes (routes that dump the contents of all tables) are private to only dev instances of the app

## Relevant Motivation & Context
Data security and privacy 🔐 

## Testing Instructions
Make sure you can ping the routes that dump all the tables locally. After the code is deployed to digital ocean/heroku, make sure you cannot ping those routes at those sites

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [x] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
