### PR TITLE
HTC-828: fix height and width of logo on Business Account Summary

### DIFF
--- a/client/src/common/forms/ChangeImage.js
+++ b/client/src/common/forms/ChangeImage.js
@@ -24,7 +24,7 @@ const ChangeImage = (props) => {
         <div
             className={"justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md"}
         >
-            {!newImageSelected && <img src={imageAddress}/>}
+            {!newImageSelected && <img src={imageAddress} width={"150"} height={"150"}/>}
             <br/>
             <div>
                 <label><b>Upload a new logo: </b></label>


### PR DESCRIPTION
# [HTC-828](https://github.com/rachellegelden/Home-Together-Canada/issues/828)

## Summary
Fix width and height of logo on business account summary

## Relevant Motivation & Context
This will prevent really big logos from taking up the whole page

## Testing Instructions
Register as a business with a logo, go to the account summary page and make sure everything looks ok

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
