### PR TITLE
HTC-820: remove payapl temporarily from user flow

### DIFF
--- a/client/src/createListing/CreateListingContainer.js
+++ b/client/src/createListing/CreateListingContainer.js
@@ -13,7 +13,6 @@ import {withRouter} from "react-router-dom";
 import PropTypes from "prop-types";
 import {compose} from "redux";
 import {connect} from "react-redux";
-import has from 'lodash/has';
 import {USER_TYPES} from "../common/constants/users";
 import InvalidUser from "../common/error/InvalidUser";
 import {BUSINESS_SERVICE_CATEGORIES} from "./constants/serviceListingCategoriesText";
@@ -74,11 +73,11 @@ const CreateListingContainer = (props) => {
     const isUserMember = (accountType === USER_TYPES.MEMBER);
 
     useEffect(() => {
-        if (paymentStatus === PAYMENT_STATUS.APPROVED && !isSelectedSubcategoryEmpty) {
-            submitListing(classifiedListing)
-        }
+        // if (paymentStatus === PAYMENT_STATUS.APPROVED && !isSelectedSubcategoryEmpty) {
+        //     submitListing(classifiedListing)
+        // }
         if (isListingValid) {
-            setShowConfirmation(true)
+            setShowConfirmation(true);
             setConfirmationMsg(isUserMember ? CONFIRMATION_TEXT.MEMBER_LISTINGS : CONFIRMATION_TEXT.BUSINESS_LISTINGS);
         }
     }, [paymentStatus, isListingValid]);
@@ -92,13 +91,14 @@ const CreateListingContainer = (props) => {
     const onSubmitClassifieds = (listing) => {
         setSubmitted(true);
         if (!isSelectedSubcategoryEmpty) {
-            setDisplayPayment(true);
-            scroll.scrollToBottom({
-                    // set smoothness = https://www.npmjs.com/package/react-scroll
-                    smooth: 'easeInOutQuad',
-                }
-            );
-            setClassifiedListing(listing);
+            // setDisplayPayment(true);
+            // scroll.scrollToBottom({
+            //         // set smoothness = https://www.npmjs.com/package/react-scroll
+            //         smooth: 'easeInOutQuad',
+            //     }
+            // );
+            // setClassifiedListing(listing);
+            submitListing(listing); // Remove after implementing PayPal
         }
     };
 

--- a/server/controllers/validators/listingControllerValidator.js
+++ b/server/controllers/validators/listingControllerValidator.js
@@ -155,14 +155,14 @@ exports.validate = method => {
                     .custom((subcategories, { req }) => listingShouldHaveCategories(subcategories, req.body.category)),
                 body('subcategories.*')
                     .custom((subcategory, { req }) => isValidSubcategoryForSelectedCategory(subcategory, req.body.category)),
-                body('orderId')
-                    .custom((orderId, { req }) => shouldOrderIdBeDefined(orderId, req.body.type))
-                    .custom((orderId, { req }) => isOptionalFieldAValidStringLength(
-                        (req.body.type === LISTING_TYPES.CLASSIFIED),
-                        orderId,
-                        LISTING_FIELD_LENGTHS.ORDER_ID,
-                        'Order ID'
-                    ))
+                // body('orderId')
+                //     .custom((orderId, { req }) => shouldOrderIdBeDefined(orderId, req.body.type))
+                //     .custom((orderId, { req }) => isOptionalFieldAValidStringLength(
+                //         (req.body.type === LISTING_TYPES.CLASSIFIED),
+                //         orderId,
+                //         LISTING_FIELD_LENGTHS.ORDER_ID,
+                //         'Order ID'
+                //     ))
             ]
         }
         case LISTING_VALIDATION_METHODS.MEMBER_HOME_FORM: {


### PR DESCRIPTION
# [HTC-820](https://github.com/rachellegelden/Home-Together-Canada/issues/820)

## Summary
Removed PayPal from user workflow when creating a classified listing

## Relevant Motivation & Context
We will put this back in when we have Twila's banking info

## Testing Instructions
Make sure you can create a classified listing and search for it (don't forget it needs to be approved by the admin)

## Developer checklist prior to opening this pull request:

- [x] PR merges to the applicable branch (develop or feature branch)
- [x] Commits adhere to GitHub compliance (Issue #)
- [x] Comments for non-trivial changes
- [ ] No build or runtime warnings or errors introduced
- [ ] If CSS changes were introduced, change viewed in Chrome, Firefox and IE
- [ ] Unit test coverage for features
- [x] Unit tests pass
- [x] Automation tests pass 

## Reviewer
- [ ] Checkout and launch this branch locally
- [ ] Review code structure
- [ ] Review test coverage
- [ ] If CSS changes were introduced, change viewed were viewed in Chrome, Firefox and IE
